### PR TITLE
Use realpath to resolve the proper path

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -50,7 +50,7 @@ function test_packages(
 
     try
         @testset verbose = true begin
-            for package_dir in package_dirs
+            for package_dir in map(canonical, package_dirs)
                 if !isdir(package_dir)
                     @warn "Package dir is not a directory: '$package_dir'"
                     continue

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -43,9 +43,15 @@ function unix_basename(path::AbstractString)
 end
 
 """
-Make sure trailing separator is removed from the path.
+Try to resolve the path, and then make sure trailing separator is removed from it.
 """
 function canonical(path::AbstractString)
+    try
+        # attempt to resolve the path to the filesystem
+        path = realpath(path)
+    catch
+        # ignore and use the incoming string anyway
+    end
     return joinpath(splitpath(path))
 end
 


### PR DESCRIPTION
This allows packages to run tests with `test_package(".")` and we resolve the proper package name.