### PR TITLE
Use a safe name for the engine in the pool

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -567,7 +567,7 @@ function start_pool(config::Union{Config,Nothing}=nothing, size::Int=1)
         RAI.create_engine(config.context, name; size="S")
         return RAITest._wait_till_provisioned(name, 600)
     end)
-    return RAITest.resize_test_engine_pool!(size, id -> "RAIRelTest-$id")
+    return RAITest.resize_test_engine_pool!(size, id -> gen_safe_name("RAIRelTest")
 end
 
 """


### PR DESCRIPTION
This prevents concurrent CI runs from using the same engine names.