### PR TITLE
Run CI on main branch

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,9 @@
 name: CI
 on:
   pull_request:
+  push:
+    branches:
+      - main
 
 jobs:
   build_rai_rel_test:


### PR DESCRIPTION
CI was running only on pull requests. This makes it run when PRs are merged in the main branch.