### PR TITLE
Fixing bug introduced in the diff PR

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -54,7 +54,7 @@ function test_packages(
     # load default if needed
     config = or_else(() -> load_config(), config)
 
-    if !isnothing(changes) && !has_rel_or_jl_name(changes)
+    if !isnothing(changes) && !isempty(changes) && !has_rel_or_jl_name(changes)
         @info "Skipping tests because changes do not involve any Rel or Julia files..."
         return
     end


### PR DESCRIPTION
In the previous PR I added support for diffs, but the check I introduced was incompatible with the CI usage, which sends `--changes ""` when no changes are submitted (in which case we want to run all tests).