### PR TITLE
Adding name and load directives

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -522,7 +522,8 @@ end
         config::Union{Config,Nothing}=nothing,
     )
 
-Prepare a `database` to run tests in this `package_dir`.
+Prepare a `database` to run tests in this `package_dir`. Returns the name of the database
+created and prepared.
 
 Create a new database with this name, then install the package sources, and execute the
 `post-install.rel` script for the package, if it exists.
@@ -577,7 +578,7 @@ function prepare_package(
         delete_db(db, config)
         rethrow()
     end
-    return
+    return db
 end
 
 """

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -356,12 +356,10 @@ function parse_code_blocks(
                 m = match(r"load=\"(.*?)\"", line)
                 if !isnothing(m)
                     filename = joinpath(cwd, m.captures[1])
-                    @info "Loading file: '$filename'"
                     if !isfile(filename)
-                        warn(basename, "load directive poinst to a file that was not found: $(filename)")
-                    else
-                        src = read(filename, String)
+                        error("$(basename): 'load' directive poinst to a file that was not found: $(filename)")
                     end
+                    src = read(filename, String)
                 end
             end
             continue

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -422,10 +422,7 @@ function code_blocks_to_steps(blocks::Vector{CodeBlock})
     counter = 1
     steps = RAITest.Step[]
     for block in blocks
-        name = block.name
-        if isnothing(name)
-            name = block.basename * (length(blocks) > 1 ? "-$counter" : "")
-        end
+        name = (length(blocks) > 1 ? "$counter - " : "") * something(block.name, block.basename)
         step = RAITest.Step(;
             query=block.code,
             name,

--- a/test/query.rel
+++ b/test/query.rel
@@ -1,0 +1,1 @@
+def output { 5 }


### PR DESCRIPTION
Adding support for new directives.

- `name` allows us to set the name of a `CodeBlock`, which ends up setting the name of test_rel's `Step`. This improves the reporting.
- `load` allows us to load the code for the query from a file. This makes it easier to write some tests (e.g. to load the actual bootstrap query from a file).