### PR TITLE
Lookup Julia tests on the package dir, not current dir

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RAIRelTest"
 uuid = "e61cca87-0504-4c6f-968f-8447d812e169"
 authors = ["Thiago Tonelli Bartolomei <thiago.tonelli@relational.ai>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -705,7 +705,7 @@ function compute_test_selectors(changed_paths::Union{Vector{T},Nothing}) where {
             # test/std/common/test-foo.rel || test/std/common/foo_test.jl
             if (endswith(path, ".rel") && occursin("test-", path)) || endswith(path, "_tests.jl")
                 if !haskey(dict, key)
-                    # create entry for this suite, targetting only this test
+                    # create entry for this suite, targeting only this test
                     dict[key] = [unix_basename(path)]
                 elseif !isempty(dict[key])
                     # if there are already tests in the suite, add this one


### PR DESCRIPTION
The function to run Julia tests was resolving test files with respect to the current working directory, when it should resolve with respect to the package directory.