### PR TITLE
Add mark tests broken

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -555,9 +555,9 @@ function execute_block(
         end
     end
     @test block.expect_abort == aborted broken=block.broken
-    if !block.expect_errors && !block.broken
+    if !block.expect_errors
         # This will need updating when the deprecation turns into removal
-        @test block.expect_errors == errored
+        @test block.expect_errors == errored broken=block.broken
     end
     return block.broken || !((!block.expect_errors && errored) || (!block.expect_abort && aborted))
 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -362,7 +362,7 @@ function parse_code_blocks(
                 if !isnothing(m)
                     filename = joinpath(cwd, m.captures[1])
                     if !isfile(filename)
-                        error("$(basename): 'load' directive poinst to a file that was not found: $(filename)")
+                        error("$(basename): 'load' directive points to a file that was not found: $(filename)")
                     end
                     src = read(filename, String)
                 end

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -351,7 +351,7 @@ function parse_code_blocks(
             expect_warnings = contains(line, "warnings")
             expect_errors = contains(line, "errors")
             expect_abort = contains(line, "abort")
-            broken = contains(line, "@broken")
+            broken = contains(line, "broken")
             if contains(line, "name")
                 name = match(r"name=\"(.*?)\"", line).captures[1]
             else

--- a/test/helpers_test.jl
+++ b/test/helpers_test.jl
@@ -155,7 +155,7 @@ def output { 4 }
 // %% name="baz", read, write
 def output { 6 }
 
-// %% name="buzz", @broken
+// %% name="buzz", broken
 ic () requires not empty({"Oops"})
 """
         blocks = parse_code_blocks(@__DIR__, "my_code", split(code, "\n"))

--- a/test/helpers_test.jl
+++ b/test/helpers_test.jl
@@ -154,10 +154,13 @@ def output { 4 }
 // %% name="bar", load="query.rel", write
 // %% name="baz", read, write
 def output { 6 }
+
+// %% name="buzz", @broken
+ic () requires not empty({"Oops"})
 """
         blocks = parse_code_blocks(@__DIR__, "my_code", split(code, "\n"))
 
-        @test length(blocks) == 6
+        @test length(blocks) == 7
 
         @test blocks[1] == CodeBlock(
             "my_code", """
@@ -165,14 +168,14 @@ def output { 6 }
 def output { 1 }
 
 """,
-            nothing, false, false, false, false
+            nothing, false, false, false, false, false
         )
         @test blocks[2] == CodeBlock(
             "my_code", """
 def output { 2 }
 
 """,
-            nothing, false, false, false, false
+            nothing, false, false, false, false, false
         )
         @test blocks[3] == CodeBlock(
             "my_code", """
@@ -180,25 +183,31 @@ def output { 2 }
 def output { 3 }
 
 """,
-            nothing, true, false, true, true
+            nothing, true, false, true, true, false
         )
         @test blocks[4] == CodeBlock(
             "my_code", """
 def output { 4 }
 """,
-            "foo", false, true, false, false
+            "foo", false, true, false, false, false
         )
         @test blocks[5] == CodeBlock(
             "my_code", """
 def output { 5 }
 """,
-            "bar", true, false, false, false
+            "bar", true, false, false, false, false
         )
         @test blocks[6] == CodeBlock(
             "my_code", """
-def output { 6 }""",
-            "baz", true, false, false, false
-        )
+def output { 6 }
 
+""",
+            "baz", true, false, false, false, false
+        )
+        @test blocks[7] == CodeBlock(
+            "my_code", """
+ic () requires not empty({"Oops"})""",
+            "buzz", false, false, false, false, true
+        )
     end
 end


### PR DESCRIPTION
Adds the ability to mark Rel tests as broken, similar to Julia. This PR parses the new meta information and propagates the broken flag to `@test` and `RAITest.Step`.

`CodeBlock`s can be marked as broken using ~`@broken`~`broken` in the block's meta header section (`// %%`). ~I am personally unattached to the syntax, if the `@` is not preferred then let me know.~
