### PR TITLE
Fix CodeBlock test

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,5 +22,4 @@ jobs:
           julia --project=./ --color=yes  -e 'using Pkg; Pkg.build()'
 
       - name: Test RAIRelTest
-        run: |
-          julia --project=. test/runtests.jl
+        uses: julia-actions/julia-runtest@v1

--- a/test/helpers_test.jl
+++ b/test/helpers_test.jl
@@ -151,7 +151,7 @@ def output { 3 }
 
 // %% read, warnings, name="foo"
 def output { 4 }
-// %% name="bar", load="query.rel", write
+// %% name="bar", load="$(@__DIR__)/query.rel", write
 // %% name="baz", read, write
 def output { 6 }
 """


### PR DESCRIPTION
Without interpolating the parent directory, `julia test/runtests.jl` and the interactive version `] test` behave differently due to file scoping issues.

See [here](https://github.com/RelationalAI/rai-rel-test/actions/runs/11973023455/job/33381090647#step:5:21).