### PR TITLE
Fix cwd for load test

### DIFF
--- a/test/helpers_test.jl
+++ b/test/helpers_test.jl
@@ -155,7 +155,7 @@ def output { 4 }
 // %% name="baz", read, write
 def output { 6 }
 """
-        blocks = parse_code_blocks(".", "my_code", split(code, "\n"))
+        blocks = parse_code_blocks(@__DIR__, "my_code", split(code, "\n"))
 
         @test length(blocks) == 6
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,3 @@
 using Test, ReTestItems, RAIRelTest
 
-include("helpers_test.jl")
+runtests("$(@__DIR__)/helpers_test.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
 using Test, ReTestItems, RAIRelTest
 
-runtests("$(@__DIR__)/helpers_test.jl")
+@testset begin
+    include("helpers_test.jl")
+end


### PR DESCRIPTION
Test should pass the file directory as cwd. Also make sure we run the tests, which causes the build to fail if they don't pass.