### PR TITLE
Fix keywords in CodeBlock name

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -331,52 +331,62 @@ function parse_code_blocks(
     broken = false
     name = nothing
     for line in code
-        if startswith(line, "// %%")
-            if !isempty(src) && !all_comments(src)
-                block = CodeBlock(
-                    basename,
-                    src,
-                    name,
-                    write,
-                    expect_warnings,
-                    expect_errors,
-                    expect_abort,
-                    broken,
-                )
-                push!(blocks, block)
-                src = ""
-            end
-            # reset flags
-            write = contains(line, "write")
-            expect_warnings = contains(line, "warnings")
-            expect_errors = contains(line, "errors")
-            expect_abort = contains(line, "abort")
-            broken = contains(line, "broken")
-            if contains(line, "name")
-                name = match(r"name=\"(.*?)\"", line).captures[1]
-            else
-                name = nothing
-            end
-            if contains(line, "load")
-                m = match(r"load=\"(.*?)\"", line)
-                if !isnothing(m)
-                    filename = joinpath(cwd, m.captures[1])
-                    if !isfile(filename)
-                        error("$(basename): 'load' directive points to a file that was not found: $(filename)")
-                    end
-                    src = read(filename, String)
-                end
-            end
-            continue
+        if !startswith(line, "// %%")
+          src *= line
+          src *= "\n"
+          continue
         end
-        src *= line
-        src *= "\n"
+
+        # Store the current CodeBlock
+        if !isempty(src) && !all_comments(src)
+            block = CodeBlock(
+                basename,
+                strip(src),
+                name,
+                write,
+                expect_warnings,
+                expect_errors,
+                expect_abort,
+                broken,
+            )
+            push!(blocks, block)
+            src = ""
+        end
+
+        # Reset flags
+        if contains(line, "name")
+          name = match(r"name=\"(.*?)\"", line).captures[1]
+        else
+            name = nothing
+        end
+        # Remove `name` from line to avoid conflict with other keywords.
+        line = replace(line, r"name=\"(.*?)\"" => "")
+
+        if contains(line, "load")
+            m = match(r"load=\"(.*?)\"", line)
+            if !isnothing(m)
+                filename = joinpath(cwd, m.captures[1])
+                if !isfile(filename)
+                    error("$(basename): 'load' directive points to a file that was not found: $(filename)")
+                end
+                src = read(filename, String)
+            end
+        end
+        # Remove `load` for same reason.
+        line = replace(line, r"load=\"(.*?)\"" => "")
+
+        write = contains(line, "write")
+        expect_warnings = contains(line, "warnings")
+        expect_errors = contains(line, "errors")
+        expect_abort = contains(line, "abort")
+        broken = contains(line, "broken")
     end
+
     src = strip(src)
     if !isempty(src) && !all_comments(src)
         block = CodeBlock(
             basename,
-            string(src),
+            src,
             name,
             write,
             expect_warnings,

--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -356,11 +356,11 @@ function parse_code_blocks(
         # Reset flags
         if contains(line, "name")
           name = match(r"name=\"(.*?)\"", line).captures[1]
+          # Remove `name` from line to avoid conflict with other keywords.
+          line = replace(line, r"name=\"(.*?)\"" => "")
         else
             name = nothing
         end
-        # Remove `name` from line to avoid conflict with other keywords.
-        line = replace(line, r"name=\"(.*?)\"" => "")
 
         if contains(line, "load")
             m = match(r"load=\"(.*?)\"", line)
@@ -370,10 +370,11 @@ function parse_code_blocks(
                     error("$(basename): 'load' directive points to a file that was not found: $(filename)")
                 end
                 src = read(filename, String)
+
+                # Remove `load` for same reason.
+                line = replace(line, r"load=\"(.*?)\"" => "")
             end
         end
-        # Remove `load` for same reason.
-        line = replace(line, r"load=\"(.*?)\"" => "")
 
         write = contains(line, "write")
         expect_warnings = contains(line, "warnings")

--- a/test/helpers_test.jl
+++ b/test/helpers_test.jl
@@ -157,57 +157,46 @@ def output { 6 }
 
 // %% name="buzz", broken
 ic () requires not empty({"Oops"})
+
+// %% name="no errors, warnings, broken, or writes", read
+def output { 8 }
 """
         blocks = parse_code_blocks(@__DIR__, "my_code", split(code, "\n"))
 
-        @test length(blocks) == 7
+        @test length(blocks) == 8
 
         @test blocks[1] == CodeBlock(
-            "my_code", """
-// some comments
-def output { 1 }
-
-""",
+            "my_code", """// some comments
+def output { 1 }""",
             nothing, false, false, false, false, false
         )
         @test blocks[2] == CodeBlock(
-            "my_code", """
-def output { 2 }
-
-""",
+            "my_code", "def output { 2 }",
             nothing, false, false, false, false, false
         )
         @test blocks[3] == CodeBlock(
-            "my_code", """
-
-def output { 3 }
-
-""",
+            "my_code", "def output { 3 }",
             nothing, true, false, true, true, false
         )
         @test blocks[4] == CodeBlock(
-            "my_code", """
-def output { 4 }
-""",
+            "my_code", "def output { 4 }",
             "foo", false, true, false, false, false
         )
         @test blocks[5] == CodeBlock(
-            "my_code", """
-def output { 5 }
-""",
+            "my_code", "def output { 5 }",
             "bar", true, false, false, false, false
         )
         @test blocks[6] == CodeBlock(
-            "my_code", """
-def output { 6 }
-
-""",
+            "my_code", "def output { 6 }",
             "baz", true, false, false, false, false
         )
         @test blocks[7] == CodeBlock(
-            "my_code", """
-ic () requires not empty({"Oops"})""",
+            "my_code", """ic () requires not empty({"Oops"})""",
             "buzz", false, false, false, false, true
+        )
+        @test blocks[8] == CodeBlock(
+            "my_code", "def output { 8 }",
+            "no errors, warnings, broken, or writes", false, false, false, false, false
         )
     end
 end


### PR DESCRIPTION
If a directive (`errors`, `warnings`, `broken`, `abort`, `write`) is in
`name="..."`, then the flag will be set perhaps against the user's
intention.

```
// %% name="errors-123", read
```

Fix this by parsing the `name` and `load` directives first and then
removing them from the flags String.
